### PR TITLE
added localisation to the start page

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ffc-grants-eligibility-checker",
   "description": "FFC Grant Eligibility Checker",
-  "version": "1.0.46",
+  "version": "1.0.47",
   "license": "OGL-UK-3.0",
   "contributors": [
     "Andrew Folga <andrew.folga@equalexperts.com>",

--- a/src/config/machines/locale/en.js
+++ b/src/config/machines/locale/en.js
@@ -38,6 +38,6 @@ export const pages = {
     }
   },
   country: {
-    title: 'Country'
+    title: 'Generic checker screens'
   }
 };

--- a/src/config/machines/locale/en.js
+++ b/src/config/machines/locale/en.js
@@ -1,0 +1,43 @@
+export const i18n = {
+  title: 'Check if you can get a grant',
+  serviceName: 'Example Grant'
+};
+
+export const errors = {};
+
+export const pages = {
+  start: {
+    title: 'Generic checker screens',
+    useThisServiceToCheck: 'Use this service to check:',
+    listItem1: 'if you are eligible to apply for a grant for your project (takes about x minutes)',
+    listItem2:
+      'how well your project scores against the funding priorities (takes about xx minutes if you\n have all the project details)',
+    whoCanApply: 'Who can apply',
+    body2: 'You can apply if you either:',
+    body3: 'You must do the grant-funded work in England.',
+    body4: 'You can apply for up to x% of the estimated cost of project items.',
+    body5:
+      'The minimum grant for project items is £xxx (x% of £xx,000). The maximum grant you can apply for is £xxx.',
+    startNow: 'Start now',
+    beforeYouStart: 'Before you start',
+    notification: 'Highlighted content here',
+    toUseThisChecker: 'To use the checker, you need:',
+    toUseThisCheckerItem1: 'Item 1',
+    toUseThisCheckerItem2: 'Item 2',
+    toUseThisCheckerItem3: 'Item 3',
+    toUseThisCheckerItem4: 'Item 4',
+    toUseThisCheckerItem5: 'Item 5',
+    problemsUsing: {
+      title: 'Problems using the online service',
+      body: 'If you have any problems using the online service, contact xxx',
+      contactType1: 'Telephone',
+      body2: 'Telephone: xxxx xxxx xx',
+      body3: 'Monday to Friday, 9am to 5pm (except public holidays)',
+      callChargesLink: 'Find out about call charges',
+      contactType2: 'Email'
+    }
+  },
+  country: {
+    title: 'Country'
+  }
+};

--- a/src/http/routes/grant-type/get-context.js
+++ b/src/http/routes/grant-type/get-context.js
@@ -1,5 +1,6 @@
 import { app } from '../../../config/app.js';
 import { generateConfirmationId } from '../../../utils/template-utils.js';
+import { pages } from '../../../config/machines/locale/en.js';
 
 /**
  * Returns the context for hapi view
@@ -9,6 +10,7 @@ import { generateConfirmationId } from '../../../utils/template-utils.js';
  */
 export function getContext(grantTypeId, meta) {
   return {
+    pageTitle: `${app.siteTitle} - ${meta.currentPageId}`,
     showTimeout: true,
     surveyLink: `${app.surveyLink}`,
     sessionTimeoutInMin: `${app.sessionTimeoutInMins}`,
@@ -18,6 +20,7 @@ export function getContext(grantTypeId, meta) {
       analytics: true
     },
     meta: {
+      localisation: { ...pages[meta.currentPageId] },
       ...meta,
       grantTypeId,
       generateConfirmationId

--- a/src/http/routes/grant-type/get-context.spec.js
+++ b/src/http/routes/grant-type/get-context.spec.js
@@ -1,12 +1,14 @@
 import { getContext } from './get-context';
 import { app } from '../../../config/app.js';
 import { generateConfirmationId } from '../../../utils/template-utils.js';
+import { pages } from '../../../config/machines/locale/en.js';
 
 describe('getContext', () => {
   it('should return the correct context object', () => {
     const grantTypeId = 'example-grant';
 
     const expectedContext = {
+      pageTitle: `${app.siteTitle} - start`,
       showTimeout: true,
       surveyLink: `${app.surveyLink}`,
       sessionTimeoutInMin: `${app.sessionTimeoutInMins}`,
@@ -20,6 +22,7 @@ describe('getContext', () => {
         previousPageId: 'previous-page',
         nextPageId: 'next-page',
         grantTypeId: 'example-grant',
+        localisation: { ...pages.start },
         generateConfirmationId
       }
     };

--- a/src/http/routes/grant-type/grant-type.spec.js
+++ b/src/http/routes/grant-type/grant-type.spec.js
@@ -3,6 +3,7 @@ import statusCodes, { OK } from '../../../constants/status-codes.js';
 import * as Boom from '@hapi/boom';
 import { startGrantStateMachines } from '../../../server.js';
 import { generateConfirmationId } from '../../../utils/template-utils.js';
+import { pages } from '../../../config/machines/locale/en.js';
 
 const { routes, viewGrantType } = await import('./grant-type.js');
 
@@ -28,8 +29,10 @@ describe('Grant Type Tests', () => {
       nextPageId: 'country',
       hasErrors: false,
       errors: undefined,
+      localisation: { ...pages.start },
       generateConfirmationId
     },
+    pageTitle: 'FFC Grants Eligibility Checker - start',
     sessionTimeoutInMin: '15',
     showTimeout: true,
     surveyLink: 'https://example.com/survey',

--- a/src/views/pages/page.njk
+++ b/src/views/pages/page.njk
@@ -1,4 +1,14 @@
 {% extends 'layout.njk' %}
+{% block header %}
+{{
+  govukHeader({
+    homepageUrl: "https://www.gov.uk/",
+    serviceName: meta.localisation.title,
+    serviceUrl: meta.grant.startUrl
+  })
+}}
+{% endblock %}
+
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}

--- a/src/views/pages/start.njk
+++ b/src/views/pages/start.njk
@@ -3,7 +3,7 @@
 {{
   govukHeader({
     homepageUrl: "https://www.gov.uk/",
-    serviceName: "Generic checker screens",
+    serviceName: meta.localisation.title,
     serviceUrl: meta.grant.startUrl
   })
 }}
@@ -12,21 +12,22 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-xl">Generic checker screens</h1>
+      <h1 class="govuk-heading-xl">{{ meta.localisation.title }}</h1>
 
-      <p class="govuk-body">Use this service to check:</p>
+      <p class="govuk-body">{{  meta.localisation.useThisServiceToCheck }}</p>
 
       <ul class="govuk-list govuk-list--bullet">
-        <li>if you are eligible to apply for a grant for your project (takes about x minutes)</li>
         <li>
-          how well your project scores against the funding priorities (takes about xx minutes if you
-          have all the project details)
+          {{ meta.localisation.listItem1 }}
+        </li>
+        <li>
+          {{ meta.localisation.listItem2 }}
         </li>
       </ul>
 
-      <h2 class="govuk-heading-m">Who can apply</h2>
+      <h2 class="govuk-heading-m">{{  meta.localisation.useThisServiceToCheck }}</h2>
 
-      <p class="govuk-body">You can apply if you either:</p>
+      <p class="govuk-body">{{  meta.localisation.body2 }}</p>
 
       <ul class="govuk-list govuk-list--bullet">
         <li>item 1</li>
@@ -34,16 +35,11 @@
         <li>item 3</li>
       </ul>
 
-      <p class="govuk-body">You must do the grant-funded work in England.</p>
+      <p class="govuk-body">{{  meta.localisation.body3 }}</p>
+      <p class="govuk-body">{{  meta.localisation.body4 }}</p>
+      <p class="govuk-body">{{  meta.localisation.body5 }}</p>
 
-      <p class="govuk-body">You can apply for up to x% of the estimated cost of project items.</p>
-
-      <p class="govuk-body">
-        The minimum grant for project items is £xxx (x% of £xx,000). The maximum grant you can apply
-        for is £xxx.
-      </p>
-
-      <div class="govuk-inset-text">Highlighted content here</div>
+      <div class="govuk-inset-text">{{  meta.localisation.notification }}</div>
 
       <a
         id="continueBtn"
@@ -53,7 +49,7 @@
         class="govuk-button govuk-button--start"
         data-module="govuk-button"
       >
-        Start now
+        {{  meta.localisation.startNow }}
         <svg
           class="govuk-button__start-icon"
           xmlns="http://www.w3.org/2000/svg"
@@ -67,32 +63,32 @@
         </svg>
       </a>
 
-      <h2 class="govuk-heading-m">Before you start</h2>
+      <h2 class="govuk-heading-m">{{  meta.localisation.beforeYouStart }}</h2>
 
-      <p class="govuk-body">To use the checker, you need:</p>
+      <p class="govuk-body">{{  meta.localisation.toUseThisChecker }}</p>
 
       <ul class="govuk-list govuk-list--bullet">
-        <li>item 1</li>
-        <li>item 2</li>
-        <li>item 3</li>
-        <li>item 4</li>
+        <li>{{ meta.localisation.toUseThisCheckerItem1 }}</li>
+        <li>{{ meta.localisation.toUseThisCheckerItem2 }}</li>
+        <li>{{ meta.localisation.toUseThisCheckerItem3 }}</li>
+        <li>{{ meta.localisation.toUseThisCheckerItem4 }}</li>
       </ul>
 
-      <h2 class="govuk-heading-m">Problems using the online service</h2>
+      <h2 class="govuk-heading-m">{{  meta.localisation.problemsUsing.title }}</h2>
 
-      <p class="govuk-body">If you have any problems using the online service, contact xxx</p>
+      <p class="govuk-body">{{  meta.localisation.problemsUser.body }}</p>
 
-      <h3 class="govuk-heading-s">Telephone</h3>
+      <h3 class="govuk-heading-s">{{  meta.localisation.problemsUser.contactType1 }}</h3>
 
-      <p class="govuk-body">Telephone: xxxx xxxx xx</p>
+      <p class="govuk-body">{{  meta.localisation.problemsUser.body2 }}</p>
 
-      <p class="govuk-body">Monday to Friday, 9am to 5pm (except public holidays)</p>
+      <p class="govuk-body">{{  meta.localisation.problemsUser.body3 }}</p>
 
       <p class="govuk-body">
-        <a href="https://www.gov.uk/call-charges"> Find out about call charges </a>
+        <a href="https://www.gov.uk/call-charges">{{ meta.localisation.problemsUser.callChargesLink }}</a>
       </p>
 
-      <h3 class="govuk-heading-s">Email</h3>
+      <h3 class="govuk-heading-s">{{  meta.localisation.problemsUser.contactType2 }}</h3>
 
       <p class="govuk-body">
         <a href="mailto:FTF@rpa.gov.uk"> xxx@xxx.gov.uk </a>
@@ -101,7 +97,7 @@
   </div>
   <script>
     document.addEventListener('DOMContentLoaded', function() {
-      document.getElementById("continueBtn").addEventListener("click", (event) => {
+      document.getElementById("continueBtn").addEventListener("click", () => {
       fetch("/eligibility-checker/{{ meta.grantTypeId }}/transition", {
             method: "POST",
             headers: { "Content-Type": "application/json" },

--- a/test/integration/narrow/example-grant/__snapshots__/country-error.spec.js.snap
+++ b/test/integration/narrow/example-grant/__snapshots__/country-error.spec.js.snap
@@ -89,8 +89,7 @@ exports[`Country Page Error Handling snapshot should match error state snapshot 
     
 
     
-  
-  <header class="govuk-header" data-module="govuk-header">
+<header class="govuk-header" data-module="govuk-header">
   <div class="govuk-header__container govuk-width-container">
     <div class="govuk-header__logo">
       <a href="https://www.gov.uk/" class="govuk-header__link govuk-header__link--homepage">
@@ -114,9 +113,9 @@ exports[`Country Page Error Handling snapshot should match error state snapshot 
     <div class="govuk-header__content">
     
       
-      <a href="/start" class="govuk-header__link govuk-header__service-name">
-        Check if you can apply
-      </a>
+      <span class="govuk-header__service-name">
+        Generic checker screens
+      </span>
       
     
     
@@ -125,24 +124,6 @@ exports[`Country Page Error Handling snapshot should match error state snapshot 
   </div>
 </header>
 
-  <div class="govuk-grid-row govuk-width-container">
-    
-<div class="govuk-phase-banner">
-  <p class="govuk-phase-banner__content">
-    <strong class="govuk-tag govuk-phase-banner__content__tag">
-      beta
-    </strong>
-    <span class="govuk-phase-banner__text">
-      This is a new service – your
-          <a class="govuk-link" href="https://example.com/survey" target="_blank" rel="noopener noreferrer"
-            >feedback</a
-          >
-          will help us to improve it.
-    </span>
-  </p>
-</div>
-
-  </div>
 
 
     

--- a/test/integration/narrow/example-grant/__snapshots__/country.spec.js.snap
+++ b/test/integration/narrow/example-grant/__snapshots__/country.spec.js.snap
@@ -114,7 +114,7 @@ exports[`Country Page snapshot should match snapshot 1`] = `
     
       
       <span class="govuk-header__service-name">
-        Country
+        Generic checker screens
       </span>
       
     

--- a/test/integration/narrow/example-grant/__snapshots__/country.spec.js.snap
+++ b/test/integration/narrow/example-grant/__snapshots__/country.spec.js.snap
@@ -89,8 +89,7 @@ exports[`Country Page snapshot should match snapshot 1`] = `
     
 
     
-  
-  <header class="govuk-header" data-module="govuk-header">
+<header class="govuk-header" data-module="govuk-header">
   <div class="govuk-header__container govuk-width-container">
     <div class="govuk-header__logo">
       <a href="https://www.gov.uk/" class="govuk-header__link govuk-header__link--homepage">
@@ -114,9 +113,9 @@ exports[`Country Page snapshot should match snapshot 1`] = `
     <div class="govuk-header__content">
     
       
-      <a href="/start" class="govuk-header__link govuk-header__service-name">
-        Check if you can apply
-      </a>
+      <span class="govuk-header__service-name">
+        Country
+      </span>
       
     
     
@@ -125,24 +124,6 @@ exports[`Country Page snapshot should match snapshot 1`] = `
   </div>
 </header>
 
-  <div class="govuk-grid-row govuk-width-container">
-    
-<div class="govuk-phase-banner">
-  <p class="govuk-phase-banner__content">
-    <strong class="govuk-tag govuk-phase-banner__content__tag">
-      beta
-    </strong>
-    <span class="govuk-phase-banner__text">
-      This is a new service – your
-          <a class="govuk-link" href="https://example.com/survey" target="_blank" rel="noopener noreferrer"
-            >feedback</a
-          >
-          will help us to improve it.
-    </span>
-  </p>
-</div>
-
-  </div>
 
 
     

--- a/test/integration/narrow/example-grant/__snapshots__/start.spec.js.snap
+++ b/test/integration/narrow/example-grant/__snapshots__/start.spec.js.snap
@@ -219,7 +219,7 @@ exports[`Start Page snapshot should match snapshot 1`] = `
   </div>
   <script>
     document.addEventListener('DOMContentLoaded', function() {
-      document.getElementById("continueBtn").addEventListener("click", (event) => {
+      document.getElementById("continueBtn").addEventListener("click", () => {
       fetch("/eligibility-checker/example-grant/transition", {
             method: "POST",
             headers: { "Content-Type": "application/json" },

--- a/test/integration/narrow/example-grant/__snapshots__/start.spec.js.snap
+++ b/test/integration/narrow/example-grant/__snapshots__/start.spec.js.snap
@@ -138,14 +138,16 @@ exports[`Start Page snapshot should match snapshot 1`] = `
       <p class="govuk-body">Use this service to check:</p>
 
       <ul class="govuk-list govuk-list--bullet">
-        <li>if you are eligible to apply for a grant for your project (takes about x minutes)</li>
+        <li>
+          if you are eligible to apply for a grant for your project (takes about x minutes)
+        </li>
         <li>
           how well your project scores against the funding priorities (takes about xx minutes if you
-          have all the project details)
+ have all the project details)
         </li>
       </ul>
 
-      <h2 class="govuk-heading-m">Who can apply</h2>
+      <h2 class="govuk-heading-m">Use this service to check:</h2>
 
       <p class="govuk-body">You can apply if you either:</p>
 
@@ -156,13 +158,8 @@ exports[`Start Page snapshot should match snapshot 1`] = `
       </ul>
 
       <p class="govuk-body">You must do the grant-funded work in England.</p>
-
       <p class="govuk-body">You can apply for up to x% of the estimated cost of project items.</p>
-
-      <p class="govuk-body">
-        The minimum grant for project items is £xxx (x% of £xx,000). The maximum grant you can apply
-        for is £xxx.
-      </p>
+      <p class="govuk-body">The minimum grant for project items is £xxx (x% of £xx,000). The maximum grant you can apply for is £xxx.</p>
 
       <div class="govuk-inset-text">Highlighted content here</div>
 
@@ -193,27 +190,27 @@ exports[`Start Page snapshot should match snapshot 1`] = `
       <p class="govuk-body">To use the checker, you need:</p>
 
       <ul class="govuk-list govuk-list--bullet">
-        <li>item 1</li>
-        <li>item 2</li>
-        <li>item 3</li>
-        <li>item 4</li>
+        <li>Item 1</li>
+        <li>Item 2</li>
+        <li>Item 3</li>
+        <li>Item 4</li>
       </ul>
 
       <h2 class="govuk-heading-m">Problems using the online service</h2>
 
-      <p class="govuk-body">If you have any problems using the online service, contact xxx</p>
+      <p class="govuk-body"></p>
 
-      <h3 class="govuk-heading-s">Telephone</h3>
+      <h3 class="govuk-heading-s"></h3>
 
-      <p class="govuk-body">Telephone: xxxx xxxx xx</p>
+      <p class="govuk-body"></p>
 
-      <p class="govuk-body">Monday to Friday, 9am to 5pm (except public holidays)</p>
+      <p class="govuk-body"></p>
 
       <p class="govuk-body">
-        <a href="https://www.gov.uk/call-charges"> Find out about call charges </a>
+        <a href="https://www.gov.uk/call-charges"></a>
       </p>
 
-      <h3 class="govuk-heading-s">Email</h3>
+      <h3 class="govuk-heading-s"></h3>
 
       <p class="govuk-body">
         <a href="mailto:FTF@rpa.gov.uk"> xxx@xxx.gov.uk </a>


### PR DESCRIPTION
The idea behind this PR is to introduce an abstraction between content and HTML. Typically this would be for localisation purposes but for us this would be better used to make certain views and components generic, avoiding duplication.

The main functionality here is to inject data associated with a state that will be interpolated with a view rather than having the content hard coded into the view directly.

I'm not sure that the work done in this PR demonstrates the true value of this as the start pages will likely be unique to each grant type. Where the real value of this will stand out is where we have questions that follow a standardised format but need specific grant specific content displayed that doesn't belong in the state.