### PR TITLE
Tgc 339 load previous page only after state transition

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ffc-grants-eligibility-checker",
-  "version": "1.0.41",
+  "version": "1.0.42",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ffc-grants-eligibility-checker",
-      "version": "1.0.41",
+      "version": "1.0.42",
       "hasInstallScript": true,
       "license": "OGL-UK-3.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ffc-grants-eligibility-checker",
   "description": "FFC Grant Eligibility Checker",
-  "version": "1.0.41",
+  "version": "1.0.42",
   "license": "OGL-UK-3.0",
   "contributors": [
     "Andrew Folga <andrew.folga@equalexperts.com>",

--- a/src/views/layout.njk
+++ b/src/views/layout.njk
@@ -43,6 +43,7 @@
   </script>
   <script>
     document.addEventListener('DOMContentLoaded', function () {
+      event.preventDefault();
       const backLink = document.querySelector('.govuk-back-link');
       if (backLink) {
         backLink.addEventListener('click', (event) => {
@@ -54,7 +55,8 @@
               nextPageId: '{{ meta.nextPageId }}',
               previousPageId: '{{ meta.previousPageId }}'
             })
-          });
+          })
+          .then(() => window.location.href = backLink.href);
         });
       }
     });

--- a/test/integration/narrow/__snapshots__/error-pages.spec.js.snap
+++ b/test/integration/narrow/__snapshots__/error-pages.spec.js.snap
@@ -57,6 +57,7 @@ exports[`error-pages plugin snapshot should match BAD_REQUEST snapshot 1`] = `
   </script>
   <script>
     document.addEventListener('DOMContentLoaded', function () {
+      event.preventDefault();
       const backLink = document.querySelector('.govuk-back-link');
       if (backLink) {
         backLink.addEventListener('click', (event) => {
@@ -68,7 +69,8 @@ exports[`error-pages plugin snapshot should match BAD_REQUEST snapshot 1`] = `
               nextPageId: '',
               previousPageId: ''
             })
-          });
+          })
+          .then(() => window.location.href = backLink.href);
         });
       }
     });
@@ -312,6 +314,7 @@ exports[`error-pages plugin snapshot should match FORBIDDEN snapshot 1`] = `
   </script>
   <script>
     document.addEventListener('DOMContentLoaded', function () {
+      event.preventDefault();
       const backLink = document.querySelector('.govuk-back-link');
       if (backLink) {
         backLink.addEventListener('click', (event) => {
@@ -323,7 +326,8 @@ exports[`error-pages plugin snapshot should match FORBIDDEN snapshot 1`] = `
               nextPageId: '',
               previousPageId: ''
             })
-          });
+          })
+          .then(() => window.location.href = backLink.href);
         });
       }
     });
@@ -572,6 +576,7 @@ exports[`error-pages plugin snapshot should match INTERNAL_SERVER_ERROR snapshot
   </script>
   <script>
     document.addEventListener('DOMContentLoaded', function () {
+      event.preventDefault();
       const backLink = document.querySelector('.govuk-back-link');
       if (backLink) {
         backLink.addEventListener('click', (event) => {
@@ -583,7 +588,8 @@ exports[`error-pages plugin snapshot should match INTERNAL_SERVER_ERROR snapshot
               nextPageId: '',
               previousPageId: ''
             })
-          });
+          })
+          .then(() => window.location.href = backLink.href);
         });
       }
     });
@@ -831,6 +837,7 @@ exports[`error-pages plugin snapshot should match NOT_FOUND snapshot 1`] = `
   </script>
   <script>
     document.addEventListener('DOMContentLoaded', function () {
+      event.preventDefault();
       const backLink = document.querySelector('.govuk-back-link');
       if (backLink) {
         backLink.addEventListener('click', (event) => {
@@ -842,7 +849,8 @@ exports[`error-pages plugin snapshot should match NOT_FOUND snapshot 1`] = `
               nextPageId: '',
               previousPageId: ''
             })
-          });
+          })
+          .then(() => window.location.href = backLink.href);
         });
       }
     });

--- a/test/integration/narrow/example-grant/__snapshots__/confirmation.spec.js.snap
+++ b/test/integration/narrow/example-grant/__snapshots__/confirmation.spec.js.snap
@@ -57,6 +57,7 @@ exports[`Consent Page snapshot should match snapshot 1`] = `
   </script>
   <script>
     document.addEventListener('DOMContentLoaded', function () {
+      event.preventDefault();
       const backLink = document.querySelector('.govuk-back-link');
       if (backLink) {
         backLink.addEventListener('click', (event) => {
@@ -68,7 +69,8 @@ exports[`Consent Page snapshot should match snapshot 1`] = `
               nextPageId: '',
               previousPageId: ''
             })
-          });
+          })
+          .then(() => window.location.href = backLink.href);
         });
       }
     });

--- a/test/integration/narrow/example-grant/__snapshots__/consent.spec.js.snap
+++ b/test/integration/narrow/example-grant/__snapshots__/consent.spec.js.snap
@@ -57,6 +57,7 @@ exports[`Consent Page snapshot should match snapshot 1`] = `
   </script>
   <script>
     document.addEventListener('DOMContentLoaded', function () {
+      event.preventDefault();
       const backLink = document.querySelector('.govuk-back-link');
       if (backLink) {
         backLink.addEventListener('click', (event) => {
@@ -68,7 +69,8 @@ exports[`Consent Page snapshot should match snapshot 1`] = `
               nextPageId: 'confirmation',
               previousPageId: 'country'
             })
-          });
+          })
+          .then(() => window.location.href = backLink.href);
         });
       }
     });

--- a/test/integration/narrow/example-grant/__snapshots__/country.spec.js.snap
+++ b/test/integration/narrow/example-grant/__snapshots__/country.spec.js.snap
@@ -59,6 +59,7 @@ exports[`Country Page snapshot should match snapshot 1`] = `
   </script>
   <script>
     document.addEventListener('DOMContentLoaded', function () {
+      event.preventDefault();
       const backLink = document.querySelector('.govuk-back-link');
       if (backLink) {
         backLink.addEventListener('click', (event) => {
@@ -70,7 +71,8 @@ exports[`Country Page snapshot should match snapshot 1`] = `
               nextPageId: 'consent',
               previousPageId: 'start'
             })
-          });
+          })
+          .then(() => window.location.href = backLink.href);
         });
       }
     });

--- a/test/integration/narrow/example-grant/__snapshots__/start.spec.js.snap
+++ b/test/integration/narrow/example-grant/__snapshots__/start.spec.js.snap
@@ -57,6 +57,7 @@ exports[`Start Page snapshot should match snapshot 1`] = `
   </script>
   <script>
     document.addEventListener('DOMContentLoaded', function () {
+      event.preventDefault();
       const backLink = document.querySelector('.govuk-back-link');
       if (backLink) {
         backLink.addEventListener('click', (event) => {
@@ -68,7 +69,8 @@ exports[`Start Page snapshot should match snapshot 1`] = `
               nextPageId: 'country',
               previousPageId: ''
             })
-          });
+          })
+          .then(() => window.location.href = backLink.href);
         });
       }
     });

--- a/test/integration/narrow/example-grant/confirmation.spec.js
+++ b/test/integration/narrow/example-grant/confirmation.spec.js
@@ -58,9 +58,7 @@ describe('Consent Page', () => {
       url: '/eligibility-checker/example-grant/confirmation'
     });
 
-    dom = new JSDOM(confirmationPageResponse.payload, {
-      runScripts: 'dangerously'
-    });
+    dom = new JSDOM(confirmationPageResponse.payload);
 
     // Mock `fetch` in the JSDOM window
     dom.window.fetch = jest.fn().mockResolvedValue({

--- a/test/integration/narrow/example-grant/consent.spec.js
+++ b/test/integration/narrow/example-grant/consent.spec.js
@@ -43,7 +43,8 @@ describe('Consent Page', () => {
     });
 
     dom = new JSDOM(consentPageResponse.payload, {
-      runScripts: 'dangerously'
+      runScripts: 'dangerously',
+      url: 'https://checker-domain/eligibility-checker/example-grant'
     });
 
     // Mock `fetch` in the JSDOM window

--- a/test/integration/narrow/example-grant/country.spec.js
+++ b/test/integration/narrow/example-grant/country.spec.js
@@ -26,7 +26,8 @@ describe('Country Page', () => {
     });
 
     dom = new JSDOM(countryPageResponse.payload, {
-      runScripts: 'dangerously'
+      runScripts: 'dangerously',
+      url: 'https://checker-domain/eligibility-checker/example-grant'
     });
 
     // Mock `fetch` in the JSDOM window


### PR DESCRIPTION
It was currently not always guaranteed that the browser navigation to previous page happened after the state machine transitioned to previous state which was causing occasional `Page not found` errors. This ensures it always happens after the state is transitioned.