### PR TITLE
Clear page validation errors when moving back to previous page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ffc-grants-eligibility-checker",
-  "version": "1.0.42",
+  "version": "1.0.43",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ffc-grants-eligibility-checker",
-      "version": "1.0.42",
+      "version": "1.0.43",
       "hasInstallScript": true,
       "license": "OGL-UK-3.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ffc-grants-eligibility-checker",
   "description": "FFC Grant Eligibility Checker",
-  "version": "1.0.42",
+  "version": "1.0.43",
   "license": "OGL-UK-3.0",
   "contributors": [
     "Andrew Folga <andrew.folga@equalexperts.com>",

--- a/src/config/machines/example-grant-machine.js
+++ b/src/config/machines/example-grant-machine.js
@@ -156,7 +156,7 @@ export const exampleGrantMachine = createMachine({
       on: {
         BACK: {
           target: 'start',
-          actions: ['updateCurrentPageId']
+          actions: ['updateCurrentPageId', 'clearPageErrors']
         },
 
         NEXT: [

--- a/src/config/machines/example-grant-machine.spec.js
+++ b/src/config/machines/example-grant-machine.spec.js
@@ -122,7 +122,7 @@ describe('Example Grant Machine Service', () => {
     });
   });
 
-  it('should set page errors correctly when validation fails', () => {
+  it('should set page errors correctly when validation fails and clear when answer is given', () => {
     // Move to country page
     service.send({ type: 'NEXT', nextPageId: 'country' });
 
@@ -140,5 +140,41 @@ describe('Example Grant Machine Service', () => {
         message: 'Select an option'
       }
     });
+
+    // Send NEXT with a valid answer
+    service.send({
+      type: 'NEXT',
+      currentPageId: 'country',
+      answer: 'UK'
+    });
+
+    // Check that the error is cleared
+    expect(service.state.context.pageErrors).toEqual({});
+  });
+
+  it('should clear page errors when navigating backward', () => {
+    // Move to country page
+    service.send({ type: 'NEXT', nextPageId: 'country' });
+
+    // Send NEXT without an answer to trigger validation error
+    service.send({
+      type: 'NEXT',
+      currentPageId: 'country',
+      answer: null
+    });
+
+    // Ensure validation error is set
+    expect(service.state.context.pageErrors).toEqual({
+      country: {
+        key: 'countryRequired',
+        message: 'Select an option'
+      }
+    });
+
+    // Navigate backward
+    service.send({ type: 'BACK', currentPageId: 'country', previousPageId: 'start' });
+
+    // Check that the error is cleared
+    expect(service.state.context.pageErrors).toEqual({});
   });
 });

--- a/src/views/layout.njk
+++ b/src/views/layout.njk
@@ -52,6 +52,7 @@
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
               event: 'BACK',
+              currentPageId: '{{ meta.currentPageId }}',
               nextPageId: '{{ meta.nextPageId }}',
               previousPageId: '{{ meta.previousPageId }}'
             })

--- a/test/integration/narrow/__snapshots__/error-pages.spec.js.snap
+++ b/test/integration/narrow/__snapshots__/error-pages.spec.js.snap
@@ -66,6 +66,7 @@ exports[`error-pages plugin snapshot should match BAD_REQUEST snapshot 1`] = `
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
               event: 'BACK',
+              currentPageId: '',
               nextPageId: '',
               previousPageId: ''
             })
@@ -323,6 +324,7 @@ exports[`error-pages plugin snapshot should match FORBIDDEN snapshot 1`] = `
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
               event: 'BACK',
+              currentPageId: '',
               nextPageId: '',
               previousPageId: ''
             })
@@ -585,6 +587,7 @@ exports[`error-pages plugin snapshot should match INTERNAL_SERVER_ERROR snapshot
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
               event: 'BACK',
+              currentPageId: '',
               nextPageId: '',
               previousPageId: ''
             })
@@ -846,6 +849,7 @@ exports[`error-pages plugin snapshot should match NOT_FOUND snapshot 1`] = `
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
               event: 'BACK',
+              currentPageId: '',
               nextPageId: '',
               previousPageId: ''
             })

--- a/test/integration/narrow/example-grant/__snapshots__/confirmation.spec.js.snap
+++ b/test/integration/narrow/example-grant/__snapshots__/confirmation.spec.js.snap
@@ -66,6 +66,7 @@ exports[`Consent Page snapshot should match snapshot 1`] = `
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
               event: 'BACK',
+              currentPageId: 'confirmation',
               nextPageId: '',
               previousPageId: ''
             })

--- a/test/integration/narrow/example-grant/__snapshots__/consent.spec.js.snap
+++ b/test/integration/narrow/example-grant/__snapshots__/consent.spec.js.snap
@@ -66,6 +66,7 @@ exports[`Consent Page snapshot should match snapshot 1`] = `
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
               event: 'BACK',
+              currentPageId: 'consent',
               nextPageId: 'confirmation',
               previousPageId: 'country'
             })

--- a/test/integration/narrow/example-grant/__snapshots__/country.spec.js.snap
+++ b/test/integration/narrow/example-grant/__snapshots__/country.spec.js.snap
@@ -68,6 +68,7 @@ exports[`Country Page snapshot should match snapshot 1`] = `
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
               event: 'BACK',
+              currentPageId: 'country',
               nextPageId: 'consent',
               previousPageId: 'start'
             })

--- a/test/integration/narrow/example-grant/__snapshots__/start.spec.js.snap
+++ b/test/integration/narrow/example-grant/__snapshots__/start.spec.js.snap
@@ -66,6 +66,7 @@ exports[`Start Page snapshot should match snapshot 1`] = `
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
               event: 'BACK',
+              currentPageId: 'start',
               nextPageId: 'country',
               previousPageId: ''
             })

--- a/test/integration/narrow/example-grant/consent.spec.js
+++ b/test/integration/narrow/example-grant/consent.spec.js
@@ -83,6 +83,7 @@ describe('Consent Page', () => {
           method: 'POST',
           body: JSON.stringify({
             event: 'BACK',
+            currentPageId: 'consent',
             nextPageId: 'confirmation',
             previousPageId: 'country'
           })

--- a/test/integration/narrow/example-grant/country.spec.js
+++ b/test/integration/narrow/example-grant/country.spec.js
@@ -66,6 +66,7 @@ describe('Country Page', () => {
           method: 'POST',
           body: JSON.stringify({
             event: 'BACK',
+            currentPageId: 'country',
             nextPageId: 'consent',
             previousPageId: 'start'
           })


### PR DESCRIPTION
The actions that follow `country`->`start` state transition do no clear page errors. This results in the validation div being still present in the following scenario:

- Navigate to /start
- Click 'Start now'
- Now click 'Continue' without selecting an option, you get the 'There is a problem' validation div
- Now click /< Back' to go back to /start
- Click 'Start now'
- The validation div is still showing on the /country page

This PR is fixing that by adding clearPageErrors to country.on.BACK actions.