### PR TITLE
Remove 'Error'  prefix from page title when country page is invalid

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ffc-grants-eligibility-checker",
-  "version": "1.0.43",
+  "version": "1.0.44",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ffc-grants-eligibility-checker",
-      "version": "1.0.43",
+      "version": "1.0.44",
       "hasInstallScript": true,
       "license": "OGL-UK-3.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ffc-grants-eligibility-checker",
   "description": "FFC Grant Eligibility Checker",
-  "version": "1.0.43",
+  "version": "1.0.44",
   "license": "OGL-UK-3.0",
   "contributors": [
     "Andrew Folga <andrew.folga@equalexperts.com>",

--- a/src/views/pages/page.njk
+++ b/src/views/pages/page.njk
@@ -13,10 +13,6 @@
 {% set hasErrors = meta.hasErrors %}
 
 {% block pageTitle %}
-
-  {% if hasErrors  %}
-    Error:
-  {% endif %}
   {{ title }}
 {% endblock %}
 

--- a/test/integration/narrow/example-grant/__snapshots__/country-validation.spec.js.snap
+++ b/test/integration/narrow/example-grant/__snapshots__/country-validation.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Country Page snapshot should match snapshot 1`] = `
+exports[`Country Validation Page snapshot should match snapshot 1`] = `
 "<!DOCTYPE html>
 <html lang="en" class="govuk-template">
   <head>
@@ -160,17 +160,42 @@ exports[`Country Page snapshot should match snapshot 1`] = `
   <div id="content" class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds govuk-!-margin-top-2">
       
+        <div class="govuk-error-summary" data-module="govuk-error-summary">
+  <div role="alert">
+    <h2 class="govuk-error-summary__title">
+      There is a problem
+    </h2>
+    <div class="govuk-error-summary__body">
+      
+      
+        <ul class="govuk-list govuk-error-summary__list">
+        
+          <li>
+          
+            <a href="#country">Select an option</a>
+          
+          </li>
+        
+        </ul>
+      
+    </div>
+  </div>
+</div>
+
+      
       <form id="questionForm" onsubmit="handleSubmit(event)" novalidate="novalidate">
         
           
           
+            
+          
           
 
 
 
-<div class="govuk-form-group">
+<div class="govuk-form-group govuk-form-group--error">
 
-  <fieldset class="govuk-fieldset" aria-describedby="country-hint">
+  <fieldset class="govuk-fieldset" aria-describedby="country-hint country-error">
     
     <legend class="govuk-fieldset__legend govuk-radios--inline govuk-fieldset__legend--l">
     
@@ -185,6 +210,14 @@ exports[`Country Page snapshot should match snapshot 1`] = `
       The site where the work will happen
     </div>
   
+  
+    
+    
+    <p id="country-error" class="govuk-error-message">
+      
+      <span class="govuk-visually-hidden">Error:</span> Select an option
+      
+    </p>
   
     <div class="govuk-radios govuk-radios--inline govuk-fieldset__legend--l" data-module="govuk-radios">
       

--- a/test/integration/narrow/example-grant/country-validation.spec.js
+++ b/test/integration/narrow/example-grant/country-validation.spec.js
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { configureServer } from '../../../../src/server';
+
+describe('Country Validation Page', () => {
+  let server;
+
+  beforeEach(async () => {
+    server = await configureServer();
+
+    // Initial navigation setup to "country" page
+    await server.inject({
+      method: 'POST',
+      url: '/eligibility-checker/example-grant/transition',
+      payload: {
+        event: 'NEXT',
+        currentPageId: 'start',
+        nextPageId: 'country'
+      }
+    });
+
+    // Transition with no answers causing validation error
+    await server.inject({
+      method: 'POST',
+      url: '/eligibility-checker/example-grant/transition',
+      payload: {
+        event: 'NEXT',
+        currentPageId: 'country',
+        nextPageId: 'consent',
+        previousPageId: 'start',
+        questionType: 'radio',
+        answer: null
+      }
+    });
+  });
+
+  afterEach(() => {
+    server.stop();
+  });
+
+  describe('snapshot', () => {
+    it('should match snapshot', async () => {
+      const response = await server.inject({
+        method: 'GET',
+        url: '/eligibility-checker/example-grant/country'
+      });
+      expect(response.payload).toMatchSnapshot();
+    });
+  });
+});


### PR DESCRIPTION
- Remove 'Error'  prefix from page title when country page is invalid
- Add snapshot ensuring country page showing validation error matches prototype